### PR TITLE
Issue #4: Fix to support the installation of Kubernetes versions >=1.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This role accept this variables:
 | ------- | ------- | ----------- |  ----------- |
 | `kubernetes_subnet`       | `yes`       |  `192.168.25.0/24` | Subnet where Kubernetess will be deployed. If the VM or bare metal server has more than one interface, Ansible will filter the interface used by Kubernetes based on the interface subnet |
 | `disable_firewall`       | `no`       | `no`       | If set to yes Ansible will disable the firewall.   |
-| `kubernetes_version`       | `no`       | `1.24.3`       | Kubernetes version to install  |
+| `kubernetes_version`       | `no`       | `1.25.0`       | Kubernetes version to install  |
 | `kubernetes_cri`       | `no`       | `containerd`       | Kubernetes [CRI](https://kubernetes.io/docs/concepts/architecture/cri/) to install.   |
 | `kubernetes_cni`       | `no`       | `flannel`       | Kubernetes [CNI](https://github.com/containernetworking/cni) to install.  |
 | `kubernetes_dns_domain`       | `no`       | `cluster.local`       | Kubernetes default DNS domain  |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@
 disable_firewall: no
 
 kubernetes_version: 1.25.0
-kubernetes_image_repository: registry.k8s.io
 kubernetes_cri: containerd
 kubernetes_cni: flannel
 kubernetes_dns_domain: cluster.local

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,8 @@
 
 disable_firewall: no
 
-kubernetes_version: 1.24.3
+kubernetes_version: 1.25.0
+kubernetes_image_repository: registry.k8s.io
 kubernetes_cri: containerd
 kubernetes_cni: flannel
 kubernetes_dns_domain: cluster.local

--- a/tasks/init_cluster.yml
+++ b/tasks/init_cluster.yml
@@ -13,6 +13,10 @@
   when: "item | ipaddr( kubernetes_subnet )"
   with_items: "{{ ansible_all_ipv4_addresses | difference([kubernetes_vip_ip]) }}"
 
+- set_fact:
+    kubernetes_image_repository: "k8s.gcr.io"
+  when: kubernetes_version is version("1.25.0", '<')
+
 - block:
 
     - set_fact:

--- a/tasks/init_cluster.yml
+++ b/tasks/init_cluster.yml
@@ -14,9 +14,8 @@
   with_items: "{{ ansible_all_ipv4_addresses | difference([kubernetes_vip_ip]) }}"
 
 - set_fact:
-    kubernetes_image_repository: "k8s.gcr.io"
-  when: kubernetes_version is version("1.25.0", '<')
-
+    kubernetes_image_repository: "{% if kubernetes_version is version('1.25.0', '<') %}k8s.gcr.io{% else %}registry.k8s.io{% endif %}"
+  
 - block:
 
     - set_fact:

--- a/templates/kubeadm-init.yml.j2
+++ b/templates/kubeadm-init.yml.j2
@@ -29,7 +29,7 @@ certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
 controllerManager: {}
 dns: {}
-imageRepository: k8s.gcr.io
+imageRepository: {{ kubernetes_image_repository }}
 kind: ClusterConfiguration
 kubernetesVersion: {{ kubernetes_version }}
 {% if groups['kubemaster'] | length > 1  %}


### PR DESCRIPTION
Issue #4: Fix to support the installation of Kubernetes versions >=1.25.0 as it requires a new image repository to be pull the images from registry.k8s.io.

Also, keep it backward compatible with versions older than 1.25.0

In addition to this, have also updated the default kubernetes_version value to 1.25.0